### PR TITLE
CLI aplication-level sandboxing

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,89 @@
+name: CLI E2E tests
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  linux:
+    name: Linux
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895 # v2.6.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Setup Go
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+        with:
+          go-version: 'stable'
+
+      - name: Install dependencies
+        run: make
+
+      - name: Build executable
+        run: make build
+
+      - run: make e2e
+
+  windows:
+    name: Windows
+    runs-on: windows-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895 # v2.6.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Setup Go
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+        with:
+          go-version: 'stable'
+
+      - name: Install dependencies
+        run: make
+
+      - name: Build executable
+        run: make build
+
+      - run: make e2e
+
+  openbsd:
+    name: OpenBSD
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895 # v2.6.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Setup Go
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+        with:
+          go-version: 'stable'
+
+      - name: Install dependencies
+        run: make
+
+      - name: Build executable for OpenBSD amd64
+        run: GOOS=openbsd GOARCH=amd64 make build
+
+      - name: Run E2E tests inside VM
+        uses: vmactions/openbsd-vm@b88817d1e198a3679fff3da785a851349da57746 # v1.0.2
+        with:
+          run: |
+            make e2e

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,6 +19,11 @@ jobs:
 
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
+      - name: Setup seccomp
+        uses: awalsh128/cache-apt-pkgs-action@44c33b32f808cdddd5ac0366d70595ed63661ed8 # v1.3.1
+        with:
+          packages: libseccomp-dev
+
       - name: Setup Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,11 @@ jobs:
         with:
           go-version: 'stable'
 
+      - name: Setup seccomp
+        uses: awalsh128/cache-apt-pkgs-action@44c33b32f808cdddd5ac0366d70595ed63661ed8 # v1.3.1
+        with:
+          packages: libseccomp-dev
+
       - name: Install dependencies
         run: make
 

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,20 @@ test:
 	@echo '# Unit tests: go test .' >&2
 	@go test .
 
+e2e:
+	@echo '# E2E tests of ./dist/sortof' >&2
+	@printf '1\n2\n3\n' >test_case.sorted
+	@printf '1\n3\n2\n' >test_case.unsorted
+	@printf '1\n3\n' >test_case.stalinsorted
+	./dist/sortof -v
+	./dist/sortof -h
+	./dist/sortof bogo <test_case.unsorted | diff test_case.sorted -
+	./dist/sortof bogo -t 5s <test_case.unsorted | diff test_case.sorted -
+	./dist/sortof slow <test_case.unsorted | diff test_case.sorted -
+	./dist/sortof slow -t 100ms <test_case.unsorted | diff test_case.sorted -
+	./dist/sortof stalin <test_case.unsorted | diff test_case.stalinsorted -
+	./dist/sortof stalin -t 400000ns <test_case.unsorted | diff test_case.stalinsorted -
+
 build: *.go
 	@echo '# Create release binary: ./dist/sortof' >&2
 	@CURRENT_VER_TAG="$$(git tag --points-at HEAD | grep "^cli" | sed 's/^cli\/v//' | sort -t. -k 1,1n -k 2,2n -k 3,3n | tail -1)"; \

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Use `make` (GNU or BSD):
 
 - `make` - install dependencies
 - `make test` - runs test
+- `make e2e` - runs e2e tests for CLI
 - `make check` - static code analysis
 - `make build` - compile binaries from latest commit
 - `make dist` - compile binaries from latest commit for supported OSes

--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ Commits with versions are tagged with:
 - `vX.X.X` (_[semantic versioning](https://semver.org/)_) - versions of Go module
 - `cli/vYYYY.0M.MICRO` (_[calendar versioning](https://calver.org/)_) - versions of command-line utility.
 
+### Security hardening
+
+On modern Linuxes and OpenBSD, CLI application has restricted access to kernel
+calls with [seccomp](https://en.wikipedia.org/wiki/Seccomp) and [pledge](https://man.openbsd.org/pledge.2).
+
 ## License
 
 [MIT](./LICENSE)

--- a/cmd/sortof/config.go
+++ b/cmd/sortof/config.go
@@ -62,7 +62,7 @@ func NewAppConfig(cliArgs []string) (AppConfig, error) {
 		return config, nil
 	}
 	if *showVersion {
-		config.ExitMessage = fmt.Sprintf("sortof %s", AppVersion)
+		config.ExitMessage = config.Version()
 		return config, nil
 	}
 
@@ -105,6 +105,15 @@ func (c AppConfig) Equal(other AppConfig) bool {
 		reflect.DeepEqual(c.Files, other.Files) &&
 		c.Timeout == other.Timeout &&
 		c.ExitMessage == other.ExitMessage
+}
+
+// Version returns string with full version description.
+func (c AppConfig) Version() string {
+	build := ""
+	if IsHardened {
+		build = " (hardened)"
+	}
+	return fmt.Sprintf("sortof %s%s", AppVersion, build)
 }
 
 // NewAppContext returns a cancellable context which is:

--- a/cmd/sortof/config_test.go
+++ b/cmd/sortof/config_test.go
@@ -13,7 +13,7 @@ func TestNewAppConfig(t *testing.T) {
 		want AppConfig
 	}{
 		{[]string{"-h"}, AppConfig{ExitMessage: helpMsg}},
-		{[]string{"-v"}, AppConfig{ExitMessage: "sortof local-dev"}},
+		{[]string{"-v"}, AppConfig{ExitMessage: "sortof local-dev (hardened)"}},
 		{[]string{"bogo"}, AppConfig{SortFunc: BogosortFile}},
 		{[]string{"bogo", "some_file"}, AppConfig{SortFunc: BogosortFile, Files: []string{"some_file"}}},
 		{[]string{"bogo", "-t", "1s"}, AppConfig{SortFunc: BogosortFile, Timeout: time.Second}},

--- a/cmd/sortof/main.go
+++ b/cmd/sortof/main.go
@@ -12,6 +12,11 @@ func main() {
 	log.SetFlags(0)
 	log.SetPrefix("sortof: ")
 
+	if err := Sandbox(); err != nil {
+		log.Println(err)
+		os.Exit(1)
+	}
+
 	config, err := NewAppConfig(os.Args[1:])
 	if err != nil {
 		log.Println(err)

--- a/cmd/sortof/sandbox.go
+++ b/cmd/sortof/sandbox.go
@@ -1,0 +1,13 @@
+// Package security contains OS specific mitigation mechanisms.
+
+//go:build !linux && !openbsd
+
+package main
+
+// IsHardened reports whether security sandbox is enabled.
+const IsHardened = false
+
+// Sandbox restrict access to system resources.
+func Sandbox() error {
+	return nil
+}

--- a/cmd/sortof/sandbox_linux.go
+++ b/cmd/sortof/sandbox_linux.go
@@ -1,0 +1,53 @@
+//go:build linux && !openbsd
+
+package main
+
+import (
+	seccomp "github.com/seccomp/libseccomp-golang"
+)
+
+// IsHardened reports whether security sandbox is enabled.
+const IsHardened = true
+
+// Sandbox restrict application access to necessary system calls needed by
+// network connections and standard i/o.
+func Sandbox() error {
+	// How to create minimal whitelist:
+	// 1. Create empty list of allowed syscalls
+	// 2. Set `seccomp.ActLog` as default filter action
+	// 3. Compile and run program
+	// 4. Use `dmesg` to find logged syscalls (started with _audit_)
+	// 5. Translate syscalls numbers to names and add them to allowed list
+	// 6. Go to point 3 and repeat until no new audit logs
+	// 7. Reset default filter action to `seccomp.ActKillProcess`
+	allowedSyscalls := []string{
+		// similar to stdio pledge
+		"clone3", "epoll_create1", "epoll_ctl", "epoll_pwait", "exit_group",
+		"fcntl", "futex", "getpid", "gettid", "mmap", "mprotect", "munmap",
+		"nanosleep", "pipe2", "read", "rseq", "rt_sigprocmask", "rt_sigreturn",
+		"sched_yield", "set_robust_list", "sigaltstack", "tgkill", "write",
+
+		// similar to rpath pledge
+		"openat",
+	}
+
+	// By default goroutines don't play well with seccomp. Program will hang
+	// when underlying thread is terminated silently. We need to kill process -
+	// see: https://github.com/golang/go/issues/3405#issuecomment-750816828
+	whitelist, err := seccomp.NewFilter(seccomp.ActKillProcess)
+	if err != nil {
+		return err
+	}
+
+	for _, callName := range allowedSyscalls {
+		callId, err := seccomp.GetSyscallFromName(callName)
+		if err != nil {
+			return err
+		}
+
+		whitelist.AddRule(callId, seccomp.ActAllow)
+	}
+	whitelist.Load()
+
+	return nil
+}

--- a/cmd/sortof/sandbox_openbsd.go
+++ b/cmd/sortof/sandbox_openbsd.go
@@ -1,0 +1,16 @@
+//go:build openbsd && !linux
+
+package main
+
+import "golang.org/x/sys/unix"
+
+// IsHardened reports whether security sandbox is enabled.
+const IsHardened = true
+
+// Sandbox restrict application access to necessary system calls needed by
+// network connections and standard i/o.
+//
+// See: https://man.openbsd.org/pledge.2
+func Sandbox() error {
+	return unix.PledgePromises("stdio rpath")
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/macie/sortof
 
 go 1.21
+
+require (
+	github.com/seccomp/libseccomp-golang v0.10.0
+	golang.org/x/sys v0.15.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/seccomp/libseccomp-golang v0.10.0 h1:aA4bp+/Zzi0BnWZ2F1wgNBs5gTpm+na2rWM6M9YjLpY=
+github.com/seccomp/libseccomp-golang v0.10.0/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=
+golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
+golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=


### PR DESCRIPTION
This change adds application-level sandboxing for CLI on Linux and OpenBSD builds by restricting kernel calls with _[seccomp](https://en.wikipedia.org/wiki/Seccomp)_ and _[pledge()](https://man.openbsd.org/pledge.2)_.
