### PR TITLE
Simplifying Makefile

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,6 +48,7 @@ jobs:
           allowed-endpoints: >
             api.github.com:443
             github.com:443
+            objects.githubusercontent.com:443
             proxy.golang.org:443
             uploads.github.com:443
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,7 +43,6 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895 # v2.6.1
         with:
-          disable-sudo: true
           egress-policy: block
           allowed-endpoints: >
             api.github.com:443
@@ -54,6 +53,11 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Setup OS
+        uses: awalsh128/cache-apt-pkgs-action@44c33b32f808cdddd5ac0366d70595ed63661ed8 # v1.3.1
+        with:
+          packages: libseccomp-dev
 
       - name: Install Go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -43,9 +43,10 @@ jobs:
         run: make
 
       - name: Build executable
-        run: make build
+        run: make sortof-linux_amd64
 
-      - run: make e2e
+      - name: Run E2E tests
+        run: make CLI=sortof-linux_amd64 e2e
 
   windows:
     name: Windows
@@ -69,9 +70,10 @@ jobs:
         run: make
 
       - name: Build executable
-        run: make build
+        run: make sortof-windows_amd64.exe
 
-      - run: make e2e
+      - name: Run E2E tests
+        run: make CLI=sortof-windows_amd64.exe e2e
 
   openbsd:
     name: OpenBSD
@@ -112,10 +114,10 @@ jobs:
         run: make
 
       - name: Build executable for OpenBSD amd64
-        run: GOOS=openbsd GOARCH=amd64 make build
+        run: make sortof-openbsd_amd64
 
       - name: Run E2E tests inside VM
         uses: vmactions/openbsd-vm@c69c6aa05e19f11533a5d00913e398606bd66133 # v1.0.4
         with:
           run: |
-            make e2e
+            make CLI=sortof-openbsd_amd64 e2e

--- a/Makefile
+++ b/Makefile
@@ -87,16 +87,11 @@ e2e:
 build:
 	@echo '# Build CLI executable: $(DESTDIR)/$(CLI)' >&2
 	$(GO) build -C $(CLI_DIR) $(GOFLAGS) $(LDFLAGS) -o '../../$(DESTDIR)/$(CLI)'
+	@echo '# Add executable checksum to: $(DESTDIR)/sha256sum.txt' >&2
+	cd $(DESTDIR); sha256sum $(CLI) >> sha256sum.txt
 
 .PHONY: dist
-dist:
-	@echo '# Create release binaries in $(DESTDIR)' >&2
-	CLI=sortof-openbsd_amd64 GOOS=openbsd GOARCH=amd64 $(GO) build -C $(CLI_DIR) $(GOFLAGS) $(LDFLAGS) -o '../../$(DESTDIR)/$(CLI)'
-	CLI=sortof-linux_amd64 GOOS=linux GOARCH=amd64 $(GO) build -C $(CLI_DIR) $(GOFLAGS) $(LDFLAGS) -o '../../$(DESTDIR)/$(CLI)'
-	CLI=sortof-windows_amd64.exe GOOS=windows GOARCH=amd64 $(GO) build -C $(CLI_DIR) $(GOFLAGS) $(LDFLAGS) -o '../../$(DESTDIR)/$(CLI)'
-
-	@echo '# Create binaries checksum' >&2
-	@sha256sum $(DESTDIR)/* >$(DESTDIR)/sha256sum.txt
+dist: sortof-linux_amd64 sortof-openbsd_amd64 sortof-windows_amd64.exe
 
 .PHONY: install-dependencies
 install-dependencies:
@@ -122,3 +117,20 @@ module-release: check test
 	@read -r NEW_VERSION; \
 		git tag "v$$NEW_VERSION"; \
 		git push --tags
+
+
+#
+# SUPPORTED EXECUTABLES
+#
+
+# this forces using `go build` for changes detection in Go related files (instead of `make`)
+.PHONY: sortof-linux_amd64 sortof-openbsd_amd64 sortof-windows_amd64.exe
+
+sortof-linux_amd64:
+	GOOS=linux GOARCH=amd64 $(MAKE) CLI=$@ build
+
+sortof-openbsd_amd64:
+	GOOS=openbsd GOARCH=amd64 $(MAKE) CLI=$@ build
+
+sortof-windows_amd64.exe:
+	GOOS=windows GOARCH=amd64 $(MAKE) CLI=$@ build


### PR DESCRIPTION
This will make `Makefile`:
- more standard looking 
- use `go build` incremental builds (instead of `make` changes detection).